### PR TITLE
Create jenkins.sh2

### DIFF
--- a/modules/jenkins-server/jenkins.sh2
+++ b/modules/jenkins-server/jenkins.sh2
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Update system packages
+echo "Updating system..."
+sudo apt-get update -y && sudo apt-get upgrade -y
+
+# Install Java (Jenkins requires Java 11+)
+echo "Installing Java..."
+sudo apt-get install -y openjdk-17-jdk
+
+# Add Jenkins Debian package repository key
+echo "Adding Jenkins repo key..."
+curl -fsSL https://pkg.jenkins.io/debian-stable/jenkins.io-2023.key | sudo tee \
+  /usr/share/keyrings/jenkins-keyring.asc > /dev/null
+
+# Add Jenkins apt repository
+echo "Adding Jenkins apt repository..."
+echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] \
+  https://pkg.jenkins.io/debian-stable binary/ | sudo tee \
+  /etc/apt/sources.list.d/jenkins.list > /dev/null
+
+# Update package list again
+echo "Updating package list..."
+sudo apt-get update -y
+
+# Install Jenkins
+echo "Installing Jenkins..."
+sudo apt-get install -y jenkins
+
+# Enable and start Jenkins
+echo "Starting and enabling Jenkins service..."
+sudo systemctl enable jenkins
+sudo systemctl start jenkins
+
+# Show Jenkins status
+echo "Checking Jenkins status..."
+sudo systemctl status jenkins
+
+# Display initial admin password
+echo "Jenkins installed! Your initial admin password is:"
+sudo cat /var/lib/jenkins/secrets/initialAdminPassword


### PR DESCRIPTION
Jenkins.sh DID NOT install Jenkins but rather DOCKER. Hence i created this file with the code for installing Jenkins. I wasn't sure if it was an error so i just created a new file so as not to tamper with the code in the other file. I named this one jenkins.sh2, to avoid confusing it with the original file. The code has been tested and it works as desired.